### PR TITLE
Resolve dates dynamically

### DIFF
--- a/searvey/custom_types.py
+++ b/searvey/custom_types.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import datetime
 from typing import Any
 from typing import Dict
 from typing import TypeVar
+from typing import Union
 
 import numpy.typing as npt
+import pandas as pd
+from typing_extensions import TypeAlias  # "from typing" in Python 3.9+
 
 
-StrDict = Dict[str, Any]
+StrDict: TypeAlias = Dict[str, Any]
+DateLike: TypeAlias = Union[str, datetime.date, datetime.datetime, pd.Timestamp]
+
 ScalarOrArray = TypeVar("ScalarOrArray", int, float, npt.NDArray[Any])

--- a/searvey/utils.py
+++ b/searvey/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import datetime
 import itertools
 from typing import Dict
+from typing import Final
 from typing import Iterable
 from typing import Iterator
 from typing import List
@@ -9,16 +11,20 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
+import pandas as pd
 import xarray as xr
 from shapely.geometry import box
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Polygon
 
 from . import models
+from .custom_types import DateLike
 from .custom_types import ScalarOrArray
 
 _T = TypeVar("_T")
 _U = TypeVar("_U")
+
+TODAY: Final = "TODAY"
 
 
 # https://gis.stackexchange.com/questions/201789/verifying-formula-that-will-convert-longitude-0-360-to-180-to-180
@@ -32,6 +38,14 @@ def lon1_to_lon3(lon1: ScalarOrArray) -> ScalarOrArray:
 
 def lon3_to_lon1(lon3: ScalarOrArray) -> ScalarOrArray:
     return ((lon3 + 180) % 360) - 180
+
+
+def resolve_date(date: DateLike) -> datetime.date:
+    if date == TODAY:
+        date = datetime.date.today()
+    else:
+        date = pd.Timestamp(date).date()
+    return date
 
 
 def get_region_from_bbox_corners(

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+import datetime
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
 import pytest
 import shapely.geometry
 
@@ -67,6 +71,30 @@ def test_lon1_to_lon3_roundtrip(lon1: float) -> None:
 @pytest.mark.parametrize("lon3", [0.01, 45.23, 163.2, 181.1, 273.2, 332.1])
 def test_lon3_to_lon1_roundtrip(lon3: float) -> None:
     assert lon3 == pytest.approx(utils.lon1_to_lon3(utils.lon3_to_lon1(lon3)))
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        "2001-12-28",
+        pd.Timestamp("2001-12-28"),
+        datetime.date(2001, 12, 28),
+        datetime.datetime(2001, 12, 28, 12, 12, 12),
+    ],
+)
+def test_resolve_date(arg) -> None:
+    resolved = utils.resolve_date(arg)
+    assert isinstance(resolved, datetime.date)
+    assert resolved == datetime.date(2001, 12, 28)
+
+
+def test_resolve_date_default_value() -> None:
+    resolved = utils.resolve_date(utils.TODAY)
+    assert isinstance(resolved, datetime.date)
+    # There is a very small chance that this test may fail
+    # More specifically, if the following line gets executed exactly after midnight
+    # Then the dates might be different, but the chances for that are very small.
+    assert resolved == datetime.date.today()
 
 
 @pytest.mark.parametrize("symmetric", [True, False])


### PR DESCRIPTION
Due to early-binding, if no value was passed for `endtime` then we were always getting the same date (i.e. the date when the code was imported). With this commit we replace the default value with a sentinel value (`TODAY`) and we simplify the IOC/USGS functions by hiding the `endpoint` logic into `resolve_date()`.

Fixes #66