### PR TITLE
Fix bug in drop columns in normalize_coops_stations

### DIFF
--- a/searvey/coops.py
+++ b/searvey/coops.py
@@ -914,9 +914,10 @@ def normalize_coops_stations(df: pandas.DataFrame) -> geopandas.GeoDataFrame:
     # To avoid duplicate labels
     if "lon" in df.columns:
         df.loc[df.lon.notnull(), "lng"] = df.lon[df.lon.notnull()]
+        df = df.drop(columns=["lon"])
     if "stationID" in df.columns:
         df.loc[df.stationID.notnull(), "id"] = df.stationID[df.stationID.notnull()]
-    df = df.drop(columns=["lon", "stationID"])
+        df = df.drop(columns=["stationID"])
     df = df.rename(
         columns={
             "id": "nos_id",


### PR DESCRIPTION
This PR fixes an issue with how columns are dropped in `normalize_coops_stations`.

As it was, `df.drop` was called with columns that might not exist, which would raise an exception. There was already logic in place to check if these columns existed, so I moved the `df.drop` to be within those `if` statements.

I ran the test suite (`make test`) and all the COOPS tests passed (overall, 166 passed, 30 warnings). 