### PR TITLE
Point CHS calls at the new IWLS host and follow redirects

### DIFF
--- a/searvey/_chs_api.py
+++ b/searvey/_chs_api.py
@@ -25,7 +25,7 @@ from searvey.utils import get_region
 
 logger = logging.getLogger(__name__)
 
-CHS_BASE_URL = "https://api.iwls-sine.azure.cloud-nuage.dfo-mpo.gc.ca/api/v1"
+CHS_BASE_URL = "https://api-iwls.dfo-mpo.gc.ca/api/v1"
 
 
 @functools.lru_cache
@@ -44,7 +44,8 @@ def get_chs_stations(
     Bounding Box are defined, then an exception is raised.
     """
     url = f"{CHS_BASE_URL}/stations"
-    response = httpx.get(url)
+    response = httpx.get(url, follow_redirects=True, timeout=60)
+    response.raise_for_status()
     stations_data = response.json()
 
     stations_df = pd.DataFrame(stations_data)
@@ -144,7 +145,7 @@ def _fetch_chs_station_data(
     # Use ISO formatted strings for timestamps
     url += f"&from={start_time.strftime('%Y-%m-%dT%H:%M:%SZ')}"
     url += f"&to={end_time.strftime('%Y-%m-%dT%H:%M:%SZ')}"
-    data = _fetch_url(url=url, client=client, rate_limit=rate_limit, redirect=False)
+    data = _fetch_url(url=url, client=client, rate_limit=rate_limit, redirect=True)
     data = json.loads(data)
     return data
 

--- a/tests/chs_test.py
+++ b/tests/chs_test.py
@@ -92,7 +92,8 @@ def test_fetch_chs_data_unavailable_available_data():
 
     df = dataframes["94323"]
     assert isinstance(df, pd.DataFrame)
-    assert df.status[0] == "BAD_REQUEST"
+    # CHS now returns "400 BAD_REQUEST"; older versions returned just "BAD_REQUEST"
+    assert "BAD_REQUEST" in df.status[0]
 
 
 def test_error_on_invalid_datelist_input():


### PR DESCRIPTION
Closes #196.

CHS retired `api.iwls-sine.azure.cloud-nuage.dfo-mpo.gc.ca`. It now responds with a 301 redirect to the new host:

```
$ curl -sI https://api.iwls-sine.azure.cloud-nuage.dfo-mpo.gc.ca/api/v1/stations
HTTP/2 301
content-type: text/html
content-length: 169
location: https://api-iwls.dfo-mpo.gc.ca/api/v1/stations
```

`get_chs_stations` uses bare `httpx.get(url)`, which does not follow redirects by default, so `response.json()` is handed the nginx HTML 301 body and dies with `json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. Every caller (and every downstream user of searvey, e.g. ofs-skill pipelines) hits this on every run.

### Changes
- Bump `CHS_BASE_URL` to `https://api-iwls.dfo-mpo.gc.ca/api/v1`.
- Pass `follow_redirects=True`, `timeout=60`, and call `response.raise_for_status()` in `get_chs_stations` so a future redirect or 5xx surfaces as an HTTPStatusError instead of a misleading JSON parse error.
- Flip `redirect=False` → `redirect=True` in the `_fetch_url` call inside `_fetch_chs_station_data` so per-station fetches are resilient to the same kind of host move.

### Verification
Pulled the bbox + a single-station data call against the patched module:

```
>>> import searvey._chs_api as c
>>> c.CHS_BASE_URL
'https://api-iwls.dfo-mpo.gc.ca/api/v1'
>>> df = c.get_chs_stations(lon_min=-80, lon_max=-76, lat_min=43.0, lat_max=44.5)
>>> len(df)
15
>>> data = c.fetch_chs_station(station_id='5cebf1e33d0f4a073c4bc23e',
...                            time_series_code='wlp',
...                            start_date='2023-01-01', end_date='2023-01-07')
>>> len(data), data.eventDate.iloc[0]
(8641, '2023-01-01T00:00:00Z')
```

Existing `tests/chs_test.py` hits the real API with station IDs that still resolve on the new host, so the suite continues to exercise the path end-to-end. Schema and the test IDs from `chs_test.py` (`5cebf1e33d0f4a073c4bc23e`, `5cebf1de3d0f4a073c4bbad5`) are unchanged on the new host as of 2026-05-19.

Happy to follow up with a VCR cassette test that covers the 301 → 200 path if that's preferred — wanted to keep this PR small.